### PR TITLE
refactor : 상품 감소 병렬 처리시 동시성 문제 제어

### DIFF
--- a/product/src/main/java/com/sparta/hotdeal/product/application/service/product/ProductInventoryService.java
+++ b/product/src/main/java/com/sparta/hotdeal/product/application/service/product/ProductInventoryService.java
@@ -60,7 +60,8 @@ public class ProductInventoryService {
                 .collect(Collectors.toList());
 
         // 상품들 조회
-        List<Product> products = productRepository.findAllByIdIn(productIds);
+        //List<Product> products = productRepository.findAllByIdIn(productIds);
+        List<Product> products = productRepository.findAllByIdInWithLock(productIds);
 
         // 상품이 없으면 예외 처리
         if (products.size() != reqPutProductQuantityDto.getProductList().size()) {

--- a/product/src/main/java/com/sparta/hotdeal/product/domain/repository/product/ProductRepository.java
+++ b/product/src/main/java/com/sparta/hotdeal/product/domain/repository/product/ProductRepository.java
@@ -16,4 +16,7 @@ public interface ProductRepository {
     Product save(Product product);
 
     List<Product> findAllByIdIn(List<UUID> productIds);
+
+    //비관적락
+    List<Product> findAllByIdInWithLock(List<UUID> productIds);
 }

--- a/product/src/main/java/com/sparta/hotdeal/product/infrastructure/repository/product/ProductRepositoryImpl.java
+++ b/product/src/main/java/com/sparta/hotdeal/product/infrastructure/repository/product/ProductRepositoryImpl.java
@@ -40,4 +40,9 @@ public class ProductRepositoryImpl implements ProductRepository {
     public List<Product> findAllByIdIn(List<UUID> productIds) {
         return productRepositoryJpa.findAllByIdIn(productIds);
     }
+
+    @Override
+    public List<Product> findAllByIdInWithLock(List<UUID> productIds) {
+        return productRepositoryJpa.findAllByIdInWithLock(productIds);
+    }
 }

--- a/product/src/main/java/com/sparta/hotdeal/product/infrastructure/repository/product/ProductRepositoryJpa.java
+++ b/product/src/main/java/com/sparta/hotdeal/product/infrastructure/repository/product/ProductRepositoryJpa.java
@@ -3,11 +3,20 @@ package com.sparta.hotdeal.product.infrastructure.repository.product;
 import com.sparta.hotdeal.product.domain.entity.product.Product;
 import java.util.List;
 import java.util.UUID;
+
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepositoryJpa extends JpaRepository<Product, UUID> {
 
     List<Product> findAllByIdIn(List<UUID> productIds);
+
+    //비관락
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Product p WHERE p.id IN :productIds")
+    List<Product> findAllByIdInWithLock(List<UUID> productIds);
 }

--- a/product/src/main/resources/application-local.yml
+++ b/product/src/main/resources/application-local.yml
@@ -10,6 +10,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+        use_sql_comments: true
     show-sql: true
   kafka:
     bootstrap-servers: ${LOCAL_KAFKA_ENDPOINT}
@@ -22,3 +24,13 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: debug
+        orm:
+          jdbc:
+            bind: TRACE
+


### PR DESCRIPTION
- 상품 조회시 비관적 락을 설정

### PR 타입
- [ ] 기능 추가
- [X] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feature/3/product-pessimistic-lock
### Description
- 상품 감소 토픽의 파티션을 2개로 설정
- 컨슈머에서 상품 감소 메세지를 병렬 처리
- 병렬 처리시 발생하는 동시성 문제를 비관적 락으로 해결
